### PR TITLE
Add Internal-, ExternalConnection

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -39,12 +39,14 @@ type connection struct {
 // DialContext - Dials vpp and returns a Connection
 // DialContext is 'lazy' meaning that if there is no socket yet at filename, we will continue to try
 // until there is one or the ctx is canceled.
-func DialContext(ctx context.Context, filename string) Connection {
+func DialContext(ctx context.Context, filename string) *ExternalConnection {
 	c := &connection{
 		ready: make(chan struct{}),
 	}
 	go c.connect(ctx, filename)
-	return c
+	return &ExternalConnection{
+		Connection: c,
+	}
 }
 
 func (c *connection) connect(ctx context.Context, filename string) {

--- a/connection.go
+++ b/connection.go
@@ -36,7 +36,7 @@ type connection struct {
 	err   error
 }
 
-// DialContext - Dials vpp and returns a Connection
+// DialContext - Dials vpp and returns an ExternalConnection
 // DialContext is 'lazy' meaning that if there is no socket yet at filename, we will continue to try
 // until there is one or the ctx is canceled.
 func DialContext(ctx context.Context, filename string) *ExternalConnection {

--- a/start.go
+++ b/start.go
@@ -38,23 +38,27 @@ type Connection interface {
 	api.ChannelProvider
 }
 
+// ExternalConnection is a Connection to the VPP that is external to the user application pod
 type ExternalConnection struct {
 	Connection
 }
 
+// IsExternal returns true
 func (c *ExternalConnection) IsExternal() bool {
 	return true
 }
 
+// InternalConnection is a Connection to the VPP that is internal to the user application pod
 type InternalConnection struct {
 	Connection
 }
 
+// IsExternal returns false
 func (c *InternalConnection) IsExternal() bool {
 	return false
 }
 
-// StartAndDialContext - starts vpp
+// StartAndDialContext - starts vpp and returns an InternalConnection
 // Stdout and Stderr for vpp are set to be log.Entry(ctx).Writer().
 func StartAndDialContext(ctx context.Context, opts ...Option) (conn *InternalConnection, errCh <-chan error) {
 	o := &option{

--- a/start.go
+++ b/start.go
@@ -38,9 +38,25 @@ type Connection interface {
 	api.ChannelProvider
 }
 
+type ExternalConnection struct {
+	Connection
+}
+
+func (c *ExternalConnection) IsExternal() bool {
+	return true
+}
+
+type InternalConnection struct {
+	Connection
+}
+
+func (c *InternalConnection) IsExternal() bool {
+	return false
+}
+
 // StartAndDialContext - starts vpp
 // Stdout and Stderr for vpp are set to be log.Entry(ctx).Writer().
-func StartAndDialContext(ctx context.Context, opts ...Option) (conn Connection, errCh <-chan error) {
+func StartAndDialContext(ctx context.Context, opts ...Option) (conn *InternalConnection, errCh <-chan error) {
 	o := &option{
 		rootDir:   DefaultRootDir,
 		vppConfig: vppConfContents,
@@ -70,7 +86,9 @@ func StartAndDialContext(ctx context.Context, opts ...Option) (conn Connection, 
 	default:
 	}
 
-	return DialContext(ctx, filepath.Join(o.rootDir, "/var/run/vpp/api.sock")), vppErrCh
+	return &InternalConnection{
+		Connection: DialContext(ctx, filepath.Join(o.rootDir, "/var/run/vpp/api.sock")),
+	}, vppErrCh
 }
 
 func writeDefaultConfigFiles(ctx context.Context, o *option) error {


### PR DESCRIPTION
## Description
1. Adds new types:
```go
type ExternalConnection struct {
	Connection
}

func (c *ExternalConnection) IsExternal() bool {
	return true
}

type InternalConnection struct {
	Connection
}

func (c *InternalConnection) IsExternal() bool {
	return false
}
```
2. Edits `DialContext` and `StartAndDialContext` to return `*ExternalConnection` and `*InternalConnection`.

## Motivation
When we create memif socket using abstract socket, we need to additionally pass application net NS to VPP. We have the following cases:
1. By location:
    1. VPP is located in the same net NS with application (internal VPP case).
    2. VPP is located in some other net NS (external VPP case).
2. By privileges:
    1. VPP has privileged access.
    2. VPP has no privileged access.

We can pass to VPP either `""` or `"file"` as a net NS:
1. `[1, 1]` - works correct.
3. `[1, 2, ""]` - works correct.
4. `[1, 2, "file"]` - fails with net NS change error.
5. `[2, 1, ""]` - creates socket in VPP net NS, incorrect.
6. `[2, 1, "file"]` - works correct.
7. `[2, 2]` - invalid setup, doesn't make sense.

In short:
1. `[1, *, ""]` - always work.
2. `[2, *, "file"]` - always work (if setup is valid).

So we need a way to distinguish internal VPP case from external VPP case.